### PR TITLE
Lesson 2 typo fix

### DIFF
--- a/lessons/02DataStructuresAndFileHandling.md
+++ b/lessons/02DataStructuresAndFileHandling.md
@@ -54,7 +54,7 @@ colors = ('red', 'green', 'blue')
 Strings are also immutable in Python.  This would cause an error:
 ```
 capital = "raleigh"
-raleigh[0] = "R"
+capital[0] = "R"
 ```
 
 ### Lists


### PR DESCRIPTION
use the variable name, not the string