### PR TITLE
Create 13Kaggle Dataset Project.md

### DIFF
--- a/lessons/13Kaggle Dataset Project.md
+++ b/lessons/13Kaggle Dataset Project.md
@@ -1,0 +1,16 @@
+# Lesson 13 — Kaggle Dataset Project
+
+## Lesson Overivew
+**Learning Objective:**
+
+**Topics**
+1. TBD
+2. TBD
+
+## Setup
+
+TBD
+
+## Summary
+
+TBD


### PR DESCRIPTION
Creating a blank lesson page for adding the Kaggle dataset project instructions. In the CTD Learns app, we can point to the datasets and instructions here, then have the rubric and submission process in the "assignments" section.